### PR TITLE
added Chassis detection for ac_state

### DIFF
--- a/auto_cpufreq/core.py
+++ b/auto_cpufreq/core.py
@@ -117,10 +117,16 @@ def charging():
     """
     power_dir = "/sys/class/power_supply/"
 
-    # AC adapter states: 0, 1, unknown
-    ac_info = getoutput(f"grep . {power_dir}A*/online").splitlines()
-    # if there's one ac-adapter on-line, ac_state is True
-    ac_state = any(['1' in ac.split(':')[-1] for ac in ac_info])
+    computer_type = getoutput('hostnamectl status | grep Chassis | cut -f2 -d \":\" | tr -d \' \'')
+    
+    if computer_type == "laptop":
+        # AC adapter states: 0, 1, unknown
+        ac_info = getoutput(f"grep . {power_dir}A*/online").splitlines()
+        # if there's one ac-adapter on-line, ac_state is True
+        ac_state = any(['1' in ac.split(':')[-1] for ac in ac_info])
+    else:
+        # if desktop ac_state is true
+        ac_state = True
 
     # Possible values: Charging, Discharging, Unknown
     battery_info = getoutput(f"grep . {power_dir}BAT*/status")


### PR DESCRIPTION
This is an updated version of the commit submitted by Librewish.

If it detects the device is a laptop, it should default to the regular method of determining ac_state
If the device returns any other output, it should default to ac_state=true

This is my first commit on github ever. I still don't really know much about programming, but with some research, I figured it out.
Couldn't fully test it because I had difficulty compiling on arch(Garuda Linux), but I think this should work in theory. 

Please test it out on your thinkpad or use your more coding-oriented brain to weed out obvious problems.